### PR TITLE
Fix search bar crash and image upload failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,9 @@ dist
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
 
+# Uploaded product images
+public/uploads/
+
 # yarn v2
 .yarn/cache
 .yarn/unplugged

--- a/public/index.html
+++ b/public/index.html
@@ -70,6 +70,10 @@
       getCatalog: async (q)=>{
         const params = new URLSearchParams(q||{}).toString();
         const res = await fetch('/api/catalog'+(params?'?'+params:''))
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}))
+          throw new Error(err.error || 'Erro ao carregar catálogo')
+        }
         return res.json()
       },
       getAdminProducts: async ()=> (await fetch('/api/admin/products')).json(),
@@ -194,6 +198,7 @@
           setCatalog(data);
         } catch (error) {
           console.error("Falha ao carregar o catálogo:", error);
+          setCatalog({ products: [], settings: { categoriesOrder: [] } });
         } finally {
           setLoading(false);
         }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 const path = require('path')
+const fs = require('fs')
 const express = require('express')
 const cors = require('cors')
 const multer = require('multer')
@@ -7,6 +8,8 @@ const { PrismaClient } = require('@prisma/client')
 const prisma = new PrismaClient()
 const app = express()
 const PORT = process.env.PORT || 4000
+const uploadDir = path.join(__dirname, '..', 'public', 'uploads')
+fs.mkdirSync(uploadDir, { recursive: true })
 
 app.use(cors())
 app.use(express.json({ limit: '2mb' }))
@@ -24,7 +27,7 @@ app.use(express.static(path.join(__dirname,'..','public')))
 // Multer storage for images
 const upload = multer({
   storage: multer.diskStorage({
-    destination: (req,file,cb)=> cb(null, path.join(__dirname,'..','public','uploads')),
+    destination: (req,file,cb)=> cb(null, uploadDir),
     filename: (req,file,cb)=> {
       const ts = Date.now()
       const safe = file.originalname.replace(/[^a-zA-Z0-9._-]/g,'_')
@@ -56,9 +59,9 @@ app.get('/api/catalog', async (req,res)=>{
     if (category) where.category = category
     if (q){
       where.OR = [
-        { name: { contains: q, mode: 'insensitive' } },
-        { codes: { contains: q, mode: 'insensitive' } },
-        { category: { contains: q, mode: 'insensitive' } },
+        { name: { contains: q } },
+        { codes: { contains: q } },
+        { category: { contains: q } },
       ]
     }
     const [products, settings] = await Promise.all([


### PR DESCRIPTION
## Summary
- handle API error responses and throw when catalog fetch fails
- reset catalog state on error to avoid blank screen
- remove unsupported Prisma case-insensitive mode so search queries return results
- ensure product image upload directory exists and ignore uploaded files

## Testing
- `curl "http://localhost:4000/api/catalog?q=Skol"`
- `curl -f -X POST -F "name=Teste" -F "category=Categoria" -F "image=@public/img/placeholder.png" http://localhost:4000/api/products`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a5074e1bd08333b5726012bb897471