### PR TITLE
Fix search bar crash and image upload failures, add scroll-to-top button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,9 @@ dist
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
 
+# Uploaded product images
+public/uploads/
+
 # yarn v2
 .yarn/cache
 .yarn/unplugged

--- a/public/index.html
+++ b/public/index.html
@@ -70,6 +70,10 @@
       getCatalog: async (q)=>{
         const params = new URLSearchParams(q||{}).toString();
         const res = await fetch('/api/catalog'+(params?'?'+params:''))
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}))
+          throw new Error(err.error || 'Erro ao carregar catálogo')
+        }
         return res.json()
       },
       getAdminProducts: async ()=> (await fetch('/api/admin/products')).json(),
@@ -139,8 +143,13 @@
     const ProductCard = ({product, showPrices})=>{
       return (
         <div className="bg-white rounded-2xl shadow-md overflow-hidden flex flex-col transition-all duration-300 hover:shadow-2xl hover:-translate-y-1">
-          <div className="bg-white p-2 relative h-48">
-            <img loading="lazy" src={product.imageUrl || '/img/placeholder.png'} alt={product.name} className="w-full h-full object-contain"/>
+          <div className="bg-white relative h-64">
+            <img
+              loading="lazy"
+              src={product.imageUrl || '/img/placeholder.png'}
+              alt={product.name}
+              className="w-full h-full object-cover"
+            />
           </div>
           <div className="p-4 flex-grow flex flex-col">
             <h3 className="font-bold text-lg leading-tight" style={{color:'var(--brand-green)'}}>{product.name}</h3>
@@ -185,6 +194,7 @@
       const [query, setQuery] = useState('');
       const [activeCategory, setActiveCategory] = useState(null);
       const [showPrices, setShowPrices] = useState(()=> localStorage.getItem('showPrices') === 'true');
+      const [showTop, setShowTop] = useState(false);
       const contentRef = useRef(null);
 
       const loadCatalog = async (searchQuery, category) => {
@@ -194,6 +204,7 @@
           setCatalog(data);
         } catch (error) {
           console.error("Falha ao carregar o catálogo:", error);
+          setCatalog({ products: [], settings: { categoriesOrder: [] } });
         } finally {
           setLoading(false);
         }
@@ -204,6 +215,12 @@
       }, []);
 
       useEffect(()=>{ localStorage.setItem('showPrices', showPrices) }, [showPrices]);
+
+      useEffect(() => {
+        const onScroll = () => setShowTop(window.scrollY > 300);
+        window.addEventListener('scroll', onScroll);
+        return () => window.removeEventListener('scroll', onScroll);
+      }, []);
 
       const handleSearchSubmit = (e) => {
           e.preventDefault();
@@ -225,6 +242,7 @@
       })).filter(g=>g.products.length>0);
 
       return (
+        <>
         <div className="container mx-auto p-4 sm:p-6 lg:p-8">
           <div className="my-8 text-center">
             <h2 className="text-3xl font-bold mb-2 text-white" style={{textShadow:'1px 1px 3px rgba(0,0,0,0.5)'}}>Certificações</h2>
@@ -318,6 +336,16 @@
             })
           )}
         </div>
+        {showTop && (
+          <button
+            onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+            className="fixed bottom-6 right-6 bg-green-600 text-white p-3 rounded-full shadow-lg hover:bg-green-700 transition-colors"
+            aria-label="Voltar ao topo"
+          >
+            ↑
+          </button>
+        )}
+        </>
       )
     };
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 const path = require('path')
+const fs = require('fs')
 const express = require('express')
 const cors = require('cors')
 const multer = require('multer')
@@ -7,6 +8,8 @@ const { PrismaClient } = require('@prisma/client')
 const prisma = new PrismaClient()
 const app = express()
 const PORT = process.env.PORT || 4000
+const uploadDir = path.join(__dirname, '..', 'public', 'uploads')
+fs.mkdirSync(uploadDir, { recursive: true })
 
 app.use(cors())
 app.use(express.json({ limit: '2mb' }))
@@ -24,7 +27,7 @@ app.use(express.static(path.join(__dirname,'..','public')))
 // Multer storage for images
 const upload = multer({
   storage: multer.diskStorage({
-    destination: (req,file,cb)=> cb(null, path.join(__dirname,'..','public','uploads')),
+    destination: (req,file,cb)=> cb(null, uploadDir),
     filename: (req,file,cb)=> {
       const ts = Date.now()
       const safe = file.originalname.replace(/[^a-zA-Z0-9._-]/g,'_')
@@ -56,9 +59,9 @@ app.get('/api/catalog', async (req,res)=>{
     if (category) where.category = category
     if (q){
       where.OR = [
-        { name: { contains: q, mode: 'insensitive' } },
-        { codes: { contains: q, mode: 'insensitive' } },
-        { category: { contains: q, mode: 'insensitive' } },
+        { name: { contains: q } },
+        { codes: { contains: q } },
+        { category: { contains: q } },
       ]
     }
     const [products, settings] = await Promise.all([


### PR DESCRIPTION
## Summary
- handle API error responses and throw when catalog fetch fails
- reset catalog state on error to avoid blank screen
- remove unsupported Prisma case-insensitive mode so search queries return results
- ensure product image upload directory exists and ignore uploaded files
- enlarge product images in catalog cards for better visibility
- add fixed "voltar ao topo" button that appears after scrolling for easier navigation

## Testing
- `curl -s http://localhost:4000/api/catalog?q=Skol | jq '.products[0].name'`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a5074e1bd08333b5726012bb897471