### PR TITLE
fix(runtime): GitHub persistence + Render compat (no-ephemeral)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,24 @@
 {
   "name": "igorvalen-fullstack",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "igorvalen-fullstack",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "dependencies": {
         "@prisma/client": "^5.22.0",
         "cors": "^2.8.5",
         "express": "^4.19.2",
-        "multer": "^1.4.5-lts.2"
+        "multer": "^1.4.5-lts.2",
+        "undici": "^6.0.0"
       },
       "devDependencies": {
         "prisma": "^5.22.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@prisma/client": {
@@ -1077,6 +1081,15 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -15,12 +15,13 @@
     "@prisma/client": "^5.22.0",
     "cors": "^2.8.5",
     "express": "^4.19.2",
-    "multer": "^1.4.5-lts.2"
+    "multer": "^1.4.5-lts.2",
+    "undici": "^6.0.0"
   },
   "devDependencies": {
     "prisma": "^5.22.0"
   },
   "engines": {
-    "node": ">=18 <23"
+    "node": ">=18"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,189 +1,221 @@
-const path = require('path')
-const fs = require('fs')
-const express = require('express')
-const cors = require('cors')
-const multer = require('multer')
-const { PrismaClient } = require('@prisma/client')
+'use strict';
 
-const prisma = new PrismaClient()
-const app = express()
-const PORT = process.env.PORT || 4000
-const uploadDir = path.join(__dirname, '..', 'public', 'uploads')
-fs.mkdirSync(uploadDir, { recursive: true })
+const path = require('path');
+const fs = require('fs');
+const express = require('express');
+const cors = require('cors');
+const multer = require('multer');
+const store = require('./services/githubStore');
 
-app.use(cors())
-app.use(express.json({ limit: '2mb' }))
-app.use(express.urlencoded({ extended: true }))
+async function start() {
+  try {
+    await store.load();
+    console.log('[catalog] loaded from GitHub');
 
-// Evitar cache do HTML principal (ajuda contra SW/asset antigo)
-app.use((req,res,next)=>{
-  if (req.path === '/' || req.path === '/index.html'){
-    res.set('Cache-Control','no-store')
-  }
-  next()
-})
+    const app = express();
+    const PORT = process.env.PORT || 4000;
+    const uploadDir = path.join(__dirname, '..', 'public', 'uploads');
+    fs.mkdirSync(uploadDir, { recursive: true });
 
-// Arquivos estáticos
-app.use(express.static(path.join(__dirname,'..','public')))
+    app.use(cors());
+    app.use(express.json({ limit: '2mb' }));
+    app.use(express.urlencoded({ extended: true, limit: '2mb' }));
 
-// Multer (upload de imagens)
-const upload = multer({
-  storage: multer.diskStorage({
-    destination: (req,file,cb)=> cb(null, uploadDir),
-    filename: (req,file,cb)=> {
-      const ts = Date.now()
-      const safe = file.originalname.replace(/[^a-zA-Z0-9._-]/g,'_')
-      cb(null, `${ts}-${safe}`)
+    app.get('/healthz', (_req, res) => res.json({ ok: true }));
+
+  // Evitar cache do HTML principal (ajuda contra SW/asset antigo)
+  app.use((req,res,next)=>{
+    if (req.path === '/' || req.path === '/index.html'){
+      res.set('Cache-Control','no-store');
     }
-  })
-})
+    next();
+  });
 
-// Helpers
-function normalizeNumber(val){
-  if (val===undefined || val===null || val==='') return null
-  if (typeof val === 'number') return val
-  // Aceita "4,70" ou "4.70"
-  const s = String(val).replace('.', '').replace(',', '.')
-  const f = parseFloat(s)
-  return isNaN(f) ? null : f
+  // Arquivos estáticos
+  app.use(express.static(path.join(__dirname,'..','public')));
+
+  // Multer (upload de imagens)
+  const upload = multer({
+    storage: multer.diskStorage({
+      destination: (req,file,cb)=> cb(null, uploadDir),
+      filename: (req,file,cb)=> {
+        const ts = Date.now();
+        const safe = file.originalname.replace(/[^a-zA-Z0-9._-]/g,'_');
+        cb(null, `${ts}-${safe}`);
+      }
+    })
+  });
+
+  // Helpers
+  function normalizeNumber(val){
+    if (val===undefined || val===null || val==='') return null;
+    if (typeof val === 'number') return val;
+    // Aceita "4,70" ou "4.70"
+    const s = String(val).replace('.', '').replace(',', '.');
+    const f = parseFloat(s);
+    return isNaN(f) ? null : f;
+  }
+
+  function getSettings(){
+    const { settings } = store.getCache();
+    const order = settings?.categoriesOrder ? settings.categoriesOrder : [];
+    return { id: 1, categoriesOrder: order };
+  }
+
+  // ---- Public API ----
+  app.get('/api/catalog', (req,res)=>{
+    try{
+      const { q, category } = req.query;
+      const { products } = store.getCache();
+      let list = products.filter(p=>p.active);
+      if (category) list = list.filter(p=>p.category === category);
+      if (q){
+        const s = String(q).toLowerCase();
+        list = list.filter(p=>
+          (p.name||'').toLowerCase().includes(s) ||
+          (p.codes||'').toLowerCase().includes(s) ||
+          (p.category||'').toLowerCase().includes(s)
+        );
+      }
+      list = list.sort((a,b)=> (a.sortOrder||0) - (b.sortOrder||0));
+      res.json({ products: list, settings: getSettings() });
+    }catch(err){
+      console.error(err);
+      res.status(500).json({ error:'Erro ao carregar catálogo'});
+    }
+  });
+
+  // ---- Admin API ----
+  app.post('/api/login', (req,res)=>{
+    const { password } = req.body || {};
+    res.json({ ok: password === '1234' });
+  });
+
+  app.get('/api/admin/products', (req,res)=>{
+    const { products } = store.getCache();
+    const sorted = [...products].sort((a,b)=> (a.sortOrder||0) - (b.sortOrder||0));
+    res.json(sorted);
+  });
+
+  app.get('/api/products/:id', (req,res)=>{
+    const id = Number(req.params.id);
+    const { products } = store.getCache();
+    const item = products.find(p=>p.id === id);
+    if (!item) return res.status(404).json({ error:'Not found' });
+    res.json(item);
+  });
+
+  app.post('/api/products', upload.single('image'), async (req,res)=>{
+    try{
+      const body = req.body || {};
+      const catalog = store.getCache();
+      const products = catalog.products || [];
+      const nextId = products.reduce((max,p)=> Math.max(max, p.id||0), 0) + 1;
+      const data = {
+        id: nextId,
+        name: body.name || '',
+        category: body.category || '',
+        codes: body.codes || null,
+        flavors: body.flavors || null,
+        imageUrl: req.file ? `/uploads/${req.file.filename}` : (body.imageUrl || null),
+        priceUV: normalizeNumber(body.priceUV),
+        priceUP: normalizeNumber(body.priceUP),
+        priceFV: normalizeNumber(body.priceFV),
+        priceFP: normalizeNumber(body.priceFP),
+        sortOrder: Number(body.sortOrder || 0),
+        active: body.active === 'false' ? false : true,
+      };
+      const nextOrder = products.length + 1;
+      if (!data.sortOrder) data.sortOrder = nextOrder;
+      products.push(data);
+      await store.save({ ...catalog, products });
+      res.json(data);
+    }catch(err){
+      console.error(err);
+      res.status(500).json({ error:'Erro ao criar produto' });
+    }
+  });
+
+  app.put('/api/products/:id', upload.single('image'), async (req,res)=>{
+    try{
+      const id = Number(req.params.id);
+      const body = req.body || {};
+      const catalog = store.getCache();
+      const products = catalog.products || [];
+      const idx = products.findIndex(p=>p.id === id);
+      if (idx === -1) return res.status(404).json({ error:'Not found' });
+      const updates = {
+        name: body.name,
+        category: body.category,
+        codes: body.codes ?? null,
+        flavors: body.flavors ?? null,
+        priceUV: normalizeNumber(body.priceUV),
+        priceUP: normalizeNumber(body.priceUP),
+        priceFV: normalizeNumber(body.priceFV),
+        priceFP: normalizeNumber(body.priceFP),
+        active: body.active === 'false' ? false : true,
+      };
+      if (req.file){
+        updates.imageUrl = `/uploads/${req.file.filename}`;
+      }
+      products[idx] = { ...products[idx], ...updates };
+      await store.save({ ...catalog, products });
+      res.json(products[idx]);
+    }catch(err){
+      console.error(err);
+      res.status(500).json({ error:'Erro ao atualizar produto' });
+    }
+  });
+
+  app.delete('/api/products/:id', async (req,res)=>{
+    try{
+      const id = Number(req.params.id);
+      const catalog = store.getCache();
+      const products = catalog.products || [];
+      const idx = products.findIndex(p=>p.id === id);
+      if (idx === -1) return res.status(404).json({ error:'Not found' });
+      products.splice(idx,1);
+      await store.save({ ...catalog, products });
+      res.json({ ok:true });
+    }catch(err){
+      console.error(err);
+      res.status(500).json({ error:'Erro ao excluir produto' });
+    }
+  });
+
+  app.post('/api/products/reorder', async (req,res)=>{
+    try{
+      const ordered = req.body || [];
+      const catalog = store.getCache();
+      const products = catalog.products || [];
+      for (let i=0;i<ordered.length;i++){
+        const id = Number(ordered[i]);
+        const p = products.find(prod=>prod.id === id);
+        if (p) p.sortOrder = i+1;
+      }
+      await store.save({ ...catalog, products });
+      res.json({ ok:true });
+    }catch(err){
+      console.error(err);
+      res.status(500).json({ error:'Erro ao reordenar' });
+    }
+  });
+
+  // Settings endpoint
+  app.get('/api/settings', (req,res)=>{
+    res.json(getSettings());
+  });
+
+  // Fallback SPA
+  app.get('*', (req,res)=>{
+    res.sendFile(path.join(__dirname,'..','public','index.html'));
+  });
+
+  app.listen(PORT, '0.0.0.0', () => console.log(`Server up on :${PORT}`));
+  } catch (e) {
+    console.error('[bootstrap error]', e);
+    process.exit(1);
+  }
 }
 
-async function getSettings(){
-  const s = await prisma.settings.findUnique({ where:{ id:1 } })
-  const order = s?.categoriesOrder ? s.categoriesOrder.split('|') : []
-  return { id: 1, categoriesOrder: order }
-}
-
-// ---- Public API ----
-app.get('/api/catalog', async (req,res)=>{
-  try{
-    const { q, category } = req.query
-    const where = { active: true }
-    if (category) where.category = category
-    if (q){
-      where.OR = [
-        { name: { contains: q } },
-        { codes: { contains: q } },
-        { category: { contains: q } },
-      ]
-    }
-    const [products, settings] = await Promise.all([
-      prisma.product.findMany({ where, orderBy: { sortOrder: 'asc' } }),
-      getSettings()
-    ])
-    res.json({ products, settings })
-  }catch(err){
-    console.error(err)
-    res.status(500).json({ error:'Erro ao carregar catálogo'})
-  }
-})
-
-// ---- Admin API ----
-app.post('/api/login', (req,res)=>{
-  const { password } = req.body || {}
-  res.json({ ok: password === '1234' })
-})
-
-app.get('/api/admin/products', async (req,res)=>{
-  const products = await prisma.product.findMany({ orderBy:{ sortOrder:'asc' } })
-  res.json(products)
-})
-
-app.get('/api/products/:id', async (req,res)=>{
-  const id = Number(req.params.id)
-  const item = await prisma.product.findUnique({ where:{ id } })
-  if (!item) return res.status(404).json({ error:'Not found' })
-  res.json(item)
-})
-
-app.post('/api/products', upload.single('image'), async (req,res)=>{
-  try{
-    const body = req.body || {}
-    const data = {
-      name: body.name || '',
-      category: body.category || '',
-      codes: body.codes || null,
-      flavors: body.flavors || null,
-      imageUrl: req.file ? `/uploads/${req.file.filename}` : (body.imageUrl || null),
-      priceUV: normalizeNumber(body.priceUV),
-      priceUP: normalizeNumber(body.priceUP),
-      priceFV: normalizeNumber(body.priceFV),
-      priceFP: normalizeNumber(body.priceFP),
-      sortOrder: Number(body.sortOrder || 0),
-      active: body.active === 'false' ? false : true,
-    }
-    const next = await prisma.product.count() + 1
-    if (!data.sortOrder) data.sortOrder = next
-    const created = await prisma.product.create({ data })
-    res.json(created)
-  }catch(err){
-    console.error(err)
-    res.status(500).json({ error:'Erro ao criar produto' })
-  }
-})
-
-app.put('/api/products/:id', upload.single('image'), async (req,res)=>{
-  try{
-    const id = Number(req.params.id)
-    const body = req.body || {}
-    const updates = {
-      name: body.name,
-      category: body.category,
-      codes: body.codes ?? null,
-      flavors: body.flavors ?? null,
-      priceUV: normalizeNumber(body.priceUV),
-      priceUP: normalizeNumber(body.priceUP),
-      priceFV: normalizeNumber(body.priceFV),
-      priceFP: normalizeNumber(body.priceFP),
-      active: body.active === 'false' ? false : true,
-    }
-    if (req.file){
-      updates.imageUrl = `/uploads/${req.file.filename}`
-    }
-    const updated = await prisma.product.update({ where:{ id }, data: updates })
-    res.json(updated)
-  }catch(err){
-    console.error(err)
-    res.status(500).json({ error:'Erro ao atualizar produto' })
-  }
-})
-
-app.delete('/api/products/:id', async (req,res)=>{
-  try{
-    const id = Number(req.params.id)
-    await prisma.product.delete({ where:{ id } })
-    res.json({ ok:true })
-  }catch(err){
-    console.error(err)
-    res.status(500).json({ error:'Erro ao excluir produto' })
-  }
-})
-
-app.post('/api/products/reorder', async (req,res)=>{
-  try{
-    const ordered = req.body || []
-    for (let i=0;i<ordered.length;i++){
-      const id = Number(ordered[i])
-      await prisma.product.update({ where:{ id }, data:{ sortOrder: i+1 } })
-    }
-    res.json({ ok:true })
-  }catch(err){
-    console.error(err)
-    res.status(500).json({ error:'Erro ao reordenar' })
-  }
-})
-
-// Settings endpoint
-app.get('/api/settings', async (req,res)=>{
-  res.json(await getSettings())
-})
-
-// Fallback SPA
-app.get('*', (req,res)=>{
-  res.sendFile(path.join(__dirname,'..','public','index.html'))
-})
-
-// Bind 0.0.0.0 para plataformas de deploy
-app.listen(PORT, '0.0.0.0', ()=>{
-  console.log(`Servidor rodando em http://localhost:${PORT}`)
-})
+start();

--- a/src/services/githubStore.js
+++ b/src/services/githubStore.js
@@ -1,0 +1,112 @@
+// Store do catálogo usando GitHub Contents API (CommonJS)
+
+// fetch compat: usa global.fetch se existir; senão, undici
+let _fetch = globalThis.fetch;
+if (_fetch) {
+  console.log('[githubStore] using global fetch');
+} else {
+  try {
+    ({ fetch: _fetch } = require('undici'));
+    console.log('[githubStore] using undici fetch');
+  } catch (err) {
+    console.error('[githubStore] fetch not available', err);
+    throw new Error('Fetch não disponível e undici não instalado');
+  }
+}
+
+const GITHUB_API = 'https://api.github.com';
+const ownerRepo = process.env.DATA_REPO;            // ex: "Igrm55/catalogo-data"
+const branch = process.env.DATA_BRANCH || 'main';
+const filePath = process.env.DATA_PATH || 'data/catalogo.json';
+const token = process.env.GITHUB_TOKEN;
+
+function headers() {
+  return {
+    Authorization: `Bearer ${token}`,
+    'User-Agent': 'catalogo-app',
+    'Content-Type': 'application/json',
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28'
+  };
+}
+
+function ensureShape(json) {
+  if (!json || typeof json !== 'object') {
+    return { products: [], settings: { categoriesOrder: [] } };
+  }
+  if (!Array.isArray(json.products)) json.products = [];
+  if (!json.settings || typeof json.settings !== 'object') {
+    json.settings = { categoriesOrder: [] };
+  }
+  if (!Array.isArray(json.settings.categoriesOrder)) {
+    json.settings.categoriesOrder = [];
+  }
+  return json;
+}
+
+async function getFileMeta() {
+  const url = `${GITHUB_API}/repos/${ownerRepo}/contents/${encodeURIComponent(filePath)}?ref=${branch}`;
+  const res = await _fetch(url, { headers: headers() });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`GitHub getFileMeta failed: ${res.status} ${res.statusText}`);
+  return res.json();
+}
+
+async function getFile() {
+  const meta = await getFileMeta();
+  if (!meta) return { sha: null, json: null };
+  const content = Buffer.from(meta.content, meta.encoding).toString('utf8');
+  return { sha: meta.sha, json: JSON.parse(content) };
+}
+
+async function putFile(obj, message = 'chore(data): update catalog') {
+  const normalized = ensureShape(obj);
+  const content = Buffer.from(JSON.stringify(normalized, null, 2), 'utf8').toString('base64');
+  const meta = await getFileMeta(); // pega sha se já existir
+  const body = {
+    message,
+    content,
+    branch,
+    sha: meta ? meta.sha : undefined,
+    committer: {
+      name: process.env.DATA_COMMITTER_NAME || 'Catalog Bot',
+      email: process.env.DATA_COMMITTER_EMAIL || 'bot@example.com'
+    }
+  };
+  const url = `${GITHUB_API}/repos/${ownerRepo}/contents/${encodeURIComponent(filePath)}`;
+  const res = await _fetch(url, {
+    method: 'PUT',
+    headers: headers(),
+    body: JSON.stringify(body)
+  });
+  if (!res.ok) throw new Error(`GitHub putFile failed: ${res.status} ${res.statusText}`);
+  const out = await res.json();
+  return out.content.sha;
+}
+
+let cache = null;
+
+async function load() {
+  const { json } = await getFile();
+  if (!json) {
+    const initial = { products: [], settings: { categoriesOrder: [] } };
+    await putFile(initial, 'chore(data): init catalog');
+    cache = initial;
+    return cache;
+  }
+  cache = ensureShape(json);
+  return cache;
+}
+
+function getCache() {
+  if (!cache) throw new Error('Catalog cache not loaded yet');
+  return cache;
+}
+
+async function save(next) {
+  await putFile(next, `chore(data): update at ${new Date().toISOString()}`);
+  cache = ensureShape(next);
+  return cache;
+}
+
+module.exports = { load, getCache, save };


### PR DESCRIPTION
## Summary
- add GitHub-backed catalog store with fetch fallback and automatic initialization
- wrap server bootstrap without top-level await, configure middleware/routes, and listen on 0.0.0.0
- ensure bootstrap file is clean and in strict mode

## Testing
- `npm test` *(fails: Missing script: "test")*
- `DATA_REPO=Igrm55/catalogo-data DATA_BRANCH=main DATA_PATH=data/catalogo.json DATA_COMMITTER_NAME='Catalog Bot' DATA_COMMITTER_EMAIL=bot@example.com GITHUB_TOKEN=dummytoken PORT=5000 npm start` *(fails: fetch failed, connect ENETUNREACH)*


------
https://chatgpt.com/codex/tasks/task_e_68accc4625e48333bd1017eccc895c00