### PR TITLE
fix: GitHub persistence + memory fallback + render compat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,88 +1,20 @@
 {
   "name": "igorvalen-fullstack",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "igorvalen-fullstack",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "dependencies": {
-        "@prisma/client": "^5.22.0",
         "cors": "^2.8.5",
-        "express": "^4.19.2",
-        "multer": "^1.4.5-lts.2"
+        "express": "^4.21.2",
+        "multer": "^1.4.5-lts.2",
+        "undici": "^6.19.8"
       },
-      "devDependencies": {
-        "prisma": "^5.22.0"
-      }
-    },
-    "node_modules/@prisma/client": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.22.0.tgz",
-      "integrity": "sha512-M0SVXfyHnQREBKxCgyo7sffrKttwE6R8PMq330MIUF0pTwjUhLbW84pFDlf06B27XyCR++VtjugEnIHdr07SVA==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
       "engines": {
-        "node": ">=16.13"
-      },
-      "peerDependencies": {
-        "prisma": "*"
-      },
-      "peerDependenciesMeta": {
-        "prisma": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@prisma/debug": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.22.0.tgz",
-      "integrity": "sha512-AUt44v3YJeggO2ZU5BkXI7M4hu9BF2zzH2iF2V5pyXT/lRTyWiElZ7It+bRH1EshoMRxHgpYg4VB6rCM+mG5jQ==",
-      "devOptional": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@prisma/engines": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.22.0.tgz",
-      "integrity": "sha512-UNjfslWhAt06kVL3CjkuYpHAWSO6L4kDCVPegV6itt7nD1kSJavd3vhgAEhjglLJJKEdJ7oIqDJ+yHk6qO8gPA==",
-      "devOptional": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@prisma/debug": "5.22.0",
-        "@prisma/engines-version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
-        "@prisma/fetch-engine": "5.22.0",
-        "@prisma/get-platform": "5.22.0"
-      }
-    },
-    "node_modules/@prisma/engines-version": {
-      "version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2.tgz",
-      "integrity": "sha512-2PTmxFR2yHW/eB3uqWtcgRcgAbG1rwG9ZriSvQw+nnb7c4uCr3RAcGMb6/zfE88SKlC1Nj2ziUvc96Z379mHgQ==",
-      "devOptional": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@prisma/fetch-engine": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.22.0.tgz",
-      "integrity": "sha512-bkrD/Mc2fSvkQBV5EpoFcZ87AvOgDxbG99488a5cexp5Ccny+UM6MAe/UFkUC0wLYD9+9befNOqGiIJhhq+HbA==",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@prisma/debug": "5.22.0",
-        "@prisma/engines-version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
-        "@prisma/get-platform": "5.22.0"
-      }
-    },
-    "node_modules/@prisma/get-platform": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.22.0.tgz",
-      "integrity": "sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@prisma/debug": "5.22.0"
+        "node": ">=18"
       }
     },
     "node_modules/accepts": {
@@ -443,21 +375,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -761,26 +678,6 @@
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
     },
-    "node_modules/prisma": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.22.0.tgz",
-      "integrity": "sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==",
-      "devOptional": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@prisma/engines": "5.22.0"
-      },
-      "bin": {
-        "prisma": "build/index.js"
-      },
-      "engines": {
-        "node": ">=16.13"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.3"
-      }
-    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -1077,6 +974,15 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -4,23 +4,16 @@
   "private": true,
   "type": "commonjs",
   "scripts": {
-    "db:generate": "prisma generate",
-    "db:push": "prisma db push",
-    "db:seed": "node scripts/seed.cjs",
-    "db:init": "npm run db:generate && npm run db:push && npm run db:seed",
     "start": "node src/index.js",
-    "dev": "node src/index.js"
+    "test": "node -e \"console.log('ok')\""
   },
   "dependencies": {
-    "@prisma/client": "^5.22.0",
+    "express": "^4.21.2",
     "cors": "^2.8.5",
-    "express": "^4.19.2",
-    "multer": "^1.4.5-lts.2"
-  },
-  "devDependencies": {
-    "prisma": "^5.22.0"
+    "multer": "^1.4.5-lts.2",
+    "undici": "^6.19.8"
   },
   "engines": {
-    "node": ">=18 <23"
+    "node": ">=18"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,189 +1,223 @@
-const path = require('path')
-const fs = require('fs')
-const express = require('express')
-const cors = require('cors')
-const multer = require('multer')
-const { PrismaClient } = require('@prisma/client')
+'use strict';
 
-const prisma = new PrismaClient()
-const app = express()
-const PORT = process.env.PORT || 4000
-const uploadDir = path.join(__dirname, '..', 'public', 'uploads')
-fs.mkdirSync(uploadDir, { recursive: true })
+const path = require('path');
+const fs = require('fs');
+const express = require('express');
+const cors = require('cors');
+const multer = require('multer');
+const store = require('./services/githubStore');
 
-app.use(cors())
-app.use(express.json({ limit: '2mb' }))
-app.use(express.urlencoded({ extended: true }))
+async function start() {
+  try {
+    await store.load();
+    console.log('[catalog] cache loaded (github or memory fallback)');
 
-// Evitar cache do HTML principal (ajuda contra SW/asset antigo)
-app.use((req,res,next)=>{
-  if (req.path === '/' || req.path === '/index.html'){
-    res.set('Cache-Control','no-store')
-  }
-  next()
-})
+    const app = express();
+    const PORT = Number(process.env.PORT || 4000);
 
-// Arquivos estáticos
-app.use(express.static(path.join(__dirname,'..','public')))
+    // pasta de uploads
+    const uploadDir = path.join(__dirname, '..', 'public', 'uploads');
+    fs.mkdirSync(uploadDir, { recursive: true });
 
-// Multer (upload de imagens)
-const upload = multer({
-  storage: multer.diskStorage({
-    destination: (req,file,cb)=> cb(null, uploadDir),
-    filename: (req,file,cb)=> {
-      const ts = Date.now()
-      const safe = file.originalname.replace(/[^a-zA-Z0-9._-]/g,'_')
-      cb(null, `${ts}-${safe}`)
+    // middlewares
+    app.use(cors());
+    app.use(express.json({ limit: '2mb' }));
+    app.use(express.urlencoded({ extended: true }));
+
+    // healthcheck
+    app.get('/healthz', (_req, res) => res.json({ ok: true }));
+
+    // Evitar cache do HTML principal (contra SW/asset antigo)
+    app.use((req, res, next) => {
+      if (req.path === '/' || req.path === '/index.html') {
+        res.set('Cache-Control', 'no-store');
+      }
+      next();
+    });
+
+    // arquivos estáticos
+    app.use(express.static(path.join(__dirname, '..', 'public')));
+
+    // Upload (multer)
+    const upload = multer({
+      storage: multer.diskStorage({
+        destination: (_req, _file, cb) => cb(null, uploadDir),
+        filename: (_req, file, cb) => {
+          const ts = Date.now();
+          const safe = (file.originalname || 'file').replace(/[^a-zA-Z0-9._-]/g, '_');
+          cb(null, `${ts}-${safe}`);
+        }
+      })
+    });
+
+    // Helpers
+    function normalizeNumber(val) {
+      if (val === undefined || val === null || val === '') return null;
+      if (typeof val === 'number') return val;
+      const s = String(val).replace('.', '').replace(',', '.');
+      const f = parseFloat(s);
+      return Number.isNaN(f) ? null : f;
     }
-  })
-})
+    function getSettings() {
+      const { settings } = store.getCache();
+      const order = Array.isArray(settings?.categoriesOrder) ? settings.categoriesOrder : [];
+      return { id: 1, categoriesOrder: order };
+    }
 
-// Helpers
-function normalizeNumber(val){
-  if (val===undefined || val===null || val==='') return null
-  if (typeof val === 'number') return val
-  // Aceita "4,70" ou "4.70"
-  const s = String(val).replace('.', '').replace(',', '.')
-  const f = parseFloat(s)
-  return isNaN(f) ? null : f
+    // ---- Public API ----
+    app.get('/api/catalog', (req, res) => {
+      try {
+        const { q, category } = req.query;
+        const { products } = store.getCache();
+        let list = (products || []).filter(p => p.active !== false);
+        if (category) list = list.filter(p => p.category === category);
+        if (q) {
+          const s = String(q).toLowerCase();
+          list = list.filter(p =>
+            (p.name || '').toLowerCase().includes(s) ||
+            (p.codes || '').toLowerCase().includes(s) ||
+            (p.category || '').toLowerCase().includes(s)
+          );
+        }
+        list = list.sort((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0));
+        res.json({ products: list, settings: getSettings() });
+      } catch (err) {
+        console.error(err);
+        res.status(500).json({ error: 'Erro ao carregar catálogo' });
+      }
+    });
+
+    app.get('/api/settings', (_req, res) => {
+      res.json(getSettings());
+    });
+
+    // ---- Admin API ----
+    app.post('/api/login', (req, res) => {
+      const { password } = req.body || {};
+      res.json({ ok: password === '1234' });
+    });
+
+    app.get('/api/admin/products', (_req, res) => {
+      const { products } = store.getCache();
+      const sorted = [...(products || [])].sort((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0));
+      res.json(sorted);
+    });
+
+    app.get('/api/products/:id', (req, res) => {
+      const id = Number(req.params.id);
+      const { products } = store.getCache();
+      const item = (products || []).find(p => p.id === id);
+      if (!item) return res.status(404).json({ error: 'Not found' });
+      res.json(item);
+    });
+
+    app.post('/api/products', upload.single('image'), async (req, res) => {
+      try {
+        const body = req.body || {};
+        const catalog = store.getCache();
+        const products = catalog.products || [];
+        const nextId = products.reduce((max, p) => Math.max(max, p.id || 0), 0) + 1;
+        const data = {
+          id: nextId,
+          name: body.name || '',
+          category: body.category || '',
+          codes: body.codes || null,
+          flavors: body.flavors || null,
+          imageUrl: req.file ? `/uploads/${req.file.filename}` : (body.imageUrl || null),
+          priceUV: normalizeNumber(body.priceUV),
+          priceUP: normalizeNumber(body.priceUP),
+          priceFV: normalizeNumber(body.priceFV),
+          priceFP: normalizeNumber(body.priceFP),
+          sortOrder: Number(body.sortOrder || products.length + 1),
+          active: body.active === 'false' ? false : true
+        };
+        products.push(data);
+        await store.save({ ...catalog, products });
+        res.json(data);
+      } catch (err) {
+        console.error(err);
+        res.status(500).json({ error: 'Erro ao criar produto' });
+      }
+    });
+
+    app.put('/api/products/:id', upload.single('image'), async (req, res) => {
+      try {
+        const id = Number(req.params.id);
+        const body = req.body || {};
+        const catalog = store.getCache();
+        const products = catalog.products || [];
+        const idx = products.findIndex(p => p.id === id);
+        if (idx === -1) return res.status(404).json({ error: 'Not found' });
+
+        const updates = {
+          name: body.name,
+          category: body.category,
+          codes: body.codes ?? null,
+          flavors: body.flavors ?? null,
+          priceUV: normalizeNumber(body.priceUV),
+          priceUP: normalizeNumber(body.priceUP),
+          priceFV: normalizeNumber(body.priceFV),
+          priceFP: normalizeNumber(body.priceFP),
+          active: body.active === 'false' ? false : true
+        };
+        if (req.file) updates.imageUrl = `/uploads/${req.file.filename}`;
+
+        products[idx] = { ...products[idx], ...updates };
+        await store.save({ ...catalog, products });
+        res.json(products[idx]);
+      } catch (err) {
+        console.error(err);
+        res.status(500).json({ error: 'Erro ao atualizar produto' });
+      }
+    });
+
+    app.delete('/api/products/:id', async (req, res) => {
+      try {
+        const id = Number(req.params.id);
+        const catalog = store.getCache();
+        const products = catalog.products || [];
+        const idx = products.findIndex(p => p.id === id);
+        if (idx === -1) return res.status(404).json({ error: 'Not found' });
+        products.splice(idx, 1);
+        await store.save({ ...catalog, products });
+        res.json({ ok: true });
+      } catch (err) {
+        console.error(err);
+        res.status(500).json({ error: 'Erro ao excluir produto' });
+      }
+    });
+
+    app.post('/api/products/reorder', async (req, res) => {
+      try {
+        const ordered = req.body || [];
+        const catalog = store.getCache();
+        const products = catalog.products || [];
+        for (let i = 0; i < ordered.length; i++) {
+          const id = Number(ordered[i]);
+          const p = products.find(prod => prod.id === id);
+          if (p) p.sortOrder = i + 1;
+        }
+        await store.save({ ...catalog, products });
+        res.json({ ok: true });
+      } catch (err) {
+        console.error(err);
+        res.status(500).json({ error: 'Erro ao reordenar' });
+      }
+    });
+
+    // Fallback SPA
+    app.get('*', (_req, res) => {
+      res.sendFile(path.join(__dirname, '..', 'public', 'index.html'));
+    });
+
+    // Bind 0.0.0.0 p/ Render
+    app.listen(PORT, '0.0.0.0', () => {
+      console.log(`Server up on :${PORT}`);
+    });
+  } catch (e) {
+    console.error('[bootstrap error]', e);
+    process.exit(1);
+  }
 }
 
-async function getSettings(){
-  const s = await prisma.settings.findUnique({ where:{ id:1 } })
-  const order = s?.categoriesOrder ? s.categoriesOrder.split('|') : []
-  return { id: 1, categoriesOrder: order }
-}
-
-// ---- Public API ----
-app.get('/api/catalog', async (req,res)=>{
-  try{
-    const { q, category } = req.query
-    const where = { active: true }
-    if (category) where.category = category
-    if (q){
-      where.OR = [
-        { name: { contains: q } },
-        { codes: { contains: q } },
-        { category: { contains: q } },
-      ]
-    }
-    const [products, settings] = await Promise.all([
-      prisma.product.findMany({ where, orderBy: { sortOrder: 'asc' } }),
-      getSettings()
-    ])
-    res.json({ products, settings })
-  }catch(err){
-    console.error(err)
-    res.status(500).json({ error:'Erro ao carregar catálogo'})
-  }
-})
-
-// ---- Admin API ----
-app.post('/api/login', (req,res)=>{
-  const { password } = req.body || {}
-  res.json({ ok: password === '1234' })
-})
-
-app.get('/api/admin/products', async (req,res)=>{
-  const products = await prisma.product.findMany({ orderBy:{ sortOrder:'asc' } })
-  res.json(products)
-})
-
-app.get('/api/products/:id', async (req,res)=>{
-  const id = Number(req.params.id)
-  const item = await prisma.product.findUnique({ where:{ id } })
-  if (!item) return res.status(404).json({ error:'Not found' })
-  res.json(item)
-})
-
-app.post('/api/products', upload.single('image'), async (req,res)=>{
-  try{
-    const body = req.body || {}
-    const data = {
-      name: body.name || '',
-      category: body.category || '',
-      codes: body.codes || null,
-      flavors: body.flavors || null,
-      imageUrl: req.file ? `/uploads/${req.file.filename}` : (body.imageUrl || null),
-      priceUV: normalizeNumber(body.priceUV),
-      priceUP: normalizeNumber(body.priceUP),
-      priceFV: normalizeNumber(body.priceFV),
-      priceFP: normalizeNumber(body.priceFP),
-      sortOrder: Number(body.sortOrder || 0),
-      active: body.active === 'false' ? false : true,
-    }
-    const next = await prisma.product.count() + 1
-    if (!data.sortOrder) data.sortOrder = next
-    const created = await prisma.product.create({ data })
-    res.json(created)
-  }catch(err){
-    console.error(err)
-    res.status(500).json({ error:'Erro ao criar produto' })
-  }
-})
-
-app.put('/api/products/:id', upload.single('image'), async (req,res)=>{
-  try{
-    const id = Number(req.params.id)
-    const body = req.body || {}
-    const updates = {
-      name: body.name,
-      category: body.category,
-      codes: body.codes ?? null,
-      flavors: body.flavors ?? null,
-      priceUV: normalizeNumber(body.priceUV),
-      priceUP: normalizeNumber(body.priceUP),
-      priceFV: normalizeNumber(body.priceFV),
-      priceFP: normalizeNumber(body.priceFP),
-      active: body.active === 'false' ? false : true,
-    }
-    if (req.file){
-      updates.imageUrl = `/uploads/${req.file.filename}`
-    }
-    const updated = await prisma.product.update({ where:{ id }, data: updates })
-    res.json(updated)
-  }catch(err){
-    console.error(err)
-    res.status(500).json({ error:'Erro ao atualizar produto' })
-  }
-})
-
-app.delete('/api/products/:id', async (req,res)=>{
-  try{
-    const id = Number(req.params.id)
-    await prisma.product.delete({ where:{ id } })
-    res.json({ ok:true })
-  }catch(err){
-    console.error(err)
-    res.status(500).json({ error:'Erro ao excluir produto' })
-  }
-})
-
-app.post('/api/products/reorder', async (req,res)=>{
-  try{
-    const ordered = req.body || []
-    for (let i=0;i<ordered.length;i++){
-      const id = Number(ordered[i])
-      await prisma.product.update({ where:{ id }, data:{ sortOrder: i+1 } })
-    }
-    res.json({ ok:true })
-  }catch(err){
-    console.error(err)
-    res.status(500).json({ error:'Erro ao reordenar' })
-  }
-})
-
-// Settings endpoint
-app.get('/api/settings', async (req,res)=>{
-  res.json(await getSettings())
-})
-
-// Fallback SPA
-app.get('*', (req,res)=>{
-  res.sendFile(path.join(__dirname,'..','public','index.html'))
-})
-
-// Bind 0.0.0.0 para plataformas de deploy
-app.listen(PORT, '0.0.0.0', ()=>{
-  console.log(`Servidor rodando em http://localhost:${PORT}`)
-})
+start();

--- a/src/services/githubStore.js
+++ b/src/services/githubStore.js
@@ -1,0 +1,141 @@
+'use strict';
+
+const { Buffer } = require('buffer');
+
+const GITHUB_API = 'https://api.github.com';
+
+const ownerRepo = process.env.DATA_REPO;               // ex: "lgrm55/catalogo-data"
+const branch    = process.env.DATA_BRANCH || 'main';   // ex: "main"
+const filePath  = process.env.DATA_PATH   || 'data/catalogo.json';
+const token     = process.env.GITHUB_TOKEN || '';
+
+let fetchFn = global.fetch;
+if (fetchFn) {
+  console.log('[githubStore] using global fetch');
+} else {
+  try {
+    ({ fetch: fetchFn } = require('undici'));
+    console.log('[githubStore] using undici fetch');
+  } catch {
+    // Último fallback (não deve acontecer em Node >=18, mas mantemos por segurança)
+    throw new Error('Fetch indisponível. Instale "undici" ou use Node >= 18.');
+  }
+}
+
+function headers() {
+  const h = {
+    'User-Agent': 'catalogo-app',
+    'Content-Type': 'application/json'
+  };
+  if (token) h.Authorization = `Bearer ${token}`;
+  return h;
+}
+
+async function httpJson(url, init = {}) {
+  const res = await fetchFn(url, { ...init, headers: { ...headers(), ...(init.headers || {}) } });
+  const text = await res.text();
+  let json = null;
+  try { json = text ? JSON.parse(text) : null; } catch { /* deixa json=null */ }
+  return { ok: res.ok, status: res.status, statusText: res.statusText, json, raw: text };
+}
+
+async function getFile() {
+  if (!ownerRepo) throw new Error('DATA_REPO ausente');
+  const url = `${GITHUB_API}/repos/${ownerRepo}/contents/${encodeURIComponent(filePath)}?ref=${branch}`;
+
+  const out = await httpJson(url);
+  if (out.ok) {
+    const meta = out.json;
+    const content = Buffer.from(meta.content || '', meta.encoding || 'base64').toString('utf8');
+    return { sha: meta.sha, json: JSON.parse(content || '{}') };
+  }
+  if (out.status === 404) {
+    // arquivo ainda não existe — tratamos como novo
+    return { sha: undefined, json: null };
+  }
+  throw new Error(`GitHub getFile failed: ${out.status} ${out.statusText}`);
+}
+
+async function putFile(obj, message = 'chore(data): update catalog') {
+  if (!ownerRepo) throw new Error('DATA_REPO ausente');
+  const url = `${GITHUB_API}/repos/${ownerRepo}/contents/${encodeURIComponent(filePath)}`;
+
+  let sha;
+  try { sha = (await getFile()).sha; } catch { sha = undefined; }
+
+  const content = Buffer.from(JSON.stringify(obj, null, 2), 'utf8').toString('base64');
+
+  const body = {
+    message,
+    content,
+    branch,
+    sha,
+    committer: {
+      name:  process.env.DATA_COMMITTER_NAME  || 'Catalog Bot',
+      email: process.env.DATA_COMMITTER_EMAIL || 'bot@example.com'
+    }
+  };
+
+  const out = await httpJson(url, { method: 'PUT', body: JSON.stringify(body) });
+  if (!out.ok) throw new Error(`GitHub putFile failed: ${out.status} ${out.statusText}`);
+  return out.json?.content?.sha || null;
+}
+
+// -------------- cache em memória + modo de operação --------------
+let cache = null;
+let mode  = 'github'; // 'github' | 'memory'
+
+function defaultCatalog() {
+  return { products: [], settings: { categoriesOrder: [] } };
+}
+
+async function load() {
+  try {
+    const got = await getFile();
+    if (got.json == null) {
+      // não existia — cria vazio no GitHub
+      const initial = defaultCatalog();
+      await putFile(initial, 'chore(data): initialize catalog');
+      cache = initial;
+    } else {
+      cache = got.json;
+      // saneamento mínimo
+      cache.products = Array.isArray(cache.products) ? cache.products : [];
+      cache.settings = cache.settings || { categoriesOrder: [] };
+      cache.settings.categoriesOrder = Array.isArray(cache.settings.categoriesOrder)
+        ? cache.settings.categoriesOrder
+        : [];
+    }
+    mode = 'github';
+    console.log('[githubStore] loaded from GitHub');
+    return cache;
+  } catch (err) {
+    console.warn('[githubStore] GitHub unavailable, falling back to memory:', err.message);
+    cache = defaultCatalog();
+    mode  = 'memory';
+    return cache;
+  }
+}
+
+function getCache() {
+  if (!cache) throw new Error('Catalog cache not loaded yet');
+  return cache;
+}
+
+async function save(next) {
+  cache = next;
+  if (mode === 'github') {
+    try {
+      await putFile(next, `chore(data): update at ${new Date().toISOString()}`);
+      return cache;
+    } catch (err) {
+      console.warn('[githubStore] save to GitHub failed (keeping memory):', err.message);
+      mode = 'memory';
+      return cache;
+    }
+  }
+  // em memória: apenas mantém
+  return cache;
+}
+
+module.exports = { load, getCache, save };


### PR DESCRIPTION
## Summary
- persist catalog to GitHub with memory fallback and fetch compatibility
- bootstrap server via `start()` with healthcheck, CORS, uploads, no-cache for index, and settings endpoint
- require Node 18+, add `undici` dependency, and add dummy `npm test`

## Testing
- `npm test`
- `PORT=5000 DATA_REPO=lgrm55/catalogo-data DATA_BRANCH=main DATA_PATH=data/catalogo.json DATA_COMMITTER_NAME='Catalog Bot' DATA_COMMITTER_EMAIL=bot@example.com GITHUB_TOKEN=dummytoken node src/index.js` *(falls back to memory when GitHub unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68accc4625e48333bd1017eccc895c00