### PR TITLE
Improve tablet catalog offline mode and layout

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -76,6 +76,9 @@
       'Bomboniere': (
         <svg className="w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M10 7v10.9"/><path d="M14 6.1V17"/><path d="M16 7V3a1 1 0 0 1 1.707-.707 2.5 2.5 0 0 0 2.152.717 1 1 0 0 1 1.131 1.131 2.5 2.5 0 0 0 .717 2.152A1 1 0 0 1 21 8h-4"/><path d="M16.536 7.465a5 5 0 0 0-7.072 0l-2 2a5 5 0 0 0 0 7.07 5 5 0 0 0 7.072 0l2-2a5 5 0 0 0 0-7.07"/><path d="M8 17v4a1 1 0 0 1-1.707.707 2.5 2.5 0 0 0-2.152-.717 1 1 0 0 1-1.131-1.131 2.5 2.5 0 0 0-.717-2.152A1 1 0 0 1 3 16h4"/></svg>
       ),
+      'Bombonière': (
+        <svg className="w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M10 7v10.9"/><path d="M14 6.1V17"/><path d="M16 7V3a1 1 0 0 1 1.707-.707 2.5 2.5 0 0 0 2.152.717 1 1 0 0 1 1.131 1.131 2.5 2.5 0 0 0 .717 2.152A1 1 0 0 1 21 8h-4"/><path d="M16.536 7.465a5 5 0 0 0-7.072 0l-2 2a5 5 0 0 0 0 7.07 5 5 0 0 0 7.072 0l2-2a5 5 0 0 0 0-7.07"/><path d="M8 17v4a1 1 0 0 1-1.707.707 2.5 2.5 0 0 0-2.152-.717 1 1 0 0 1-1.131-1.131 2.5 2.5 0 0 0-.717-2.152A1 1 0 0 1 3 16h4"/></svg>
+      ),
       'Bebidas não alcoólicas': (
         <svg className="w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m6 8 1.75 12.28a2 2 0 0 0 2 1.72h4.54a2 2 0 0 0 2-1.72L18 8"/><path d="M5 8h14"/><path d="M7 15a6.47 6.47 0 0 1 5 0 6.47 6.47 0 0 0 5 0"/><path d="m12 8 1-6h2"/></svg>
       ),
@@ -92,6 +95,14 @@
         <svg className="w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"/><path d="m3.3 7 8.7 5 8.7-5"/><path d="M12 22V12"/></svg>
       )
     };
+    // categorias permitidas no catálogo público
+    const ALLOWED_CATEGORIES = [
+      'Bebidas não alcoólicas',
+      'Bebidas alcoólicas',
+      'Bombonière',
+      'Cigarro',
+      'Utilidades',
+    ];
 
     const getCategoryIcon = (cat) => categoryIcons[cat] || categoryIcons.default;
 
@@ -271,7 +282,10 @@
     const AppProvider = ({children})=>{
       const [route, setRoute] = useState({name:'home', params:{}});
       const [isAdmin, setIsAdmin] = useState(false);
-      const [offline, setOffline] = useState(()=> localStorage.getItem('offline') === 'true');
+      // estado do modo offline (persistido)
+      const [offline, setOffline] = useState(()=> localStorage.getItem('offlineEnabled') === 'true');
+      // detecta perda de conexão para aviso ao usuário
+      const [isOffline,setIsOffline] = useState(!navigator.onLine);
       const navigate = (name, params = {}) => {
         let path = name === 'home' ? '/' : `/${name}`;
         if (params && typeof params.id !== 'undefined' && params.id !== null) {
@@ -301,17 +315,27 @@
       };
 
       useEffect(()=>{
+        const update = ()=>setIsOffline(!navigator.onLine);
+        addEventListener('online', update);
+        addEventListener('offline', update);
+        return ()=>{
+          removeEventListener('online', update);
+          removeEventListener('offline', update);
+        };
+      },[]);
+
+      useEffect(()=>{
         if ('serviceWorker' in navigator){
           navigator.serviceWorker.ready.then(reg=>{
-            reg.active?.postMessage({type:'offline', enabled: offline});
+            reg.active?.postMessage({type: offline? 'ENABLE_OFFLINE':'DISABLE_OFFLINE'});
           });
         }
-        localStorage.setItem('offline', offline);
+        localStorage.setItem('offlineEnabled', offline);
       }, [offline]);
 
       const toggleOffline = ()=> setOffline(v=>!v);
 
-      return <AppContext.Provider value={{route, navigate, auth, offline, toggleOffline}}>{children}</AppContext.Provider>
+      return <AppContext.Provider value={{route, navigate, auth, offline, toggleOffline, isOffline}}>{children}</AppContext.Provider>
     };
     const useApp = ()=> useContext(AppContext);
 
@@ -320,15 +344,15 @@
       const [showExportOptions, setShowExportOptions] = useState(false);
       return (
         <header className="sticky top-0 z-40 shadow-lg" style={{backgroundColor:'var(--brand-green)'}}>
-          <div className="container mx-auto px-4 sm:px-6 lg:px-8 flex items-center justify-between h-24">
-            <div className="bg-white px-4 py-2 rounded-xl shadow cursor-pointer transform hover:scale-105 transition-transform" onClick={()=>navigate('home')}>
+          <div className="max-w-screen-xl mx-auto px-4 md:px-6 lg:px-8 flex flex-wrap items-center justify-between gap-4 md:gap-6">
+            <div className="bg-white px-4 py-2 rounded-xl shadow cursor-pointer flex-shrink-0 transform hover:scale-105 transition-transform" onClick={()=>navigate('home')}>
               <div className="flex items-baseline">
                 <span className="text-3xl font-bold" style={{color:'var(--brand-green)'}}>Igor</span>
                 <span className="text-3xl font-bold" style={{color:'var(--brand-red)'}}>Valen</span>
               </div>
               <span className="block text-sm -mt-1 font-medium text-gray-800 text-right">Distribuidora</span>
             </div>
-            <div className="flex items-center space-x-4 text-white font-semibold">
+            <div className="flex items-center gap-4 md:gap-6 flex-wrap text-white font-semibold">
               <button onClick={() => navigate('home')} className="hover:text-green-200 transition-colors">Catálogo</button>
               <div className="flex items-center gap-2">
                 <span className="text-sm">Usar sem Wi-Fi</span>
@@ -348,11 +372,16 @@
       )
     };
 
+    const OfflineNotice = ()=>{
+      const { isOffline } = useApp();
+      return isOffline ? <div className="bg-yellow-100 text-yellow-800 text-center text-sm py-1">Sem conexão — exibindo dados salvos</div> : null;
+    };
+
     // *** ProductCard com layout de preços atualizado ***
     const ProductCard = ({product, priceMode, showPrices, onSelect})=>{
       return (
-        <div onClick={() => onSelect && onSelect(product)} className="bg-white rounded-2xl shadow-md overflow-hidden flex flex-col transition-all duration-300 hover:shadow-2xl hover:-translate-y-1 cursor-pointer">
-          <div className="bg-white relative h-64 flex items-center justify-center">
+        <div onClick={() => onSelect && onSelect(product)} className="rounded-2xl shadow-md border border-gray-100 bg-white/95 flex flex-col p-4 md:p-5 gap-3 transition-all duration-300 hover:shadow-2xl hover:-translate-y-1 cursor-pointer">
+          <div className="relative h-40 md:h-56 flex items-center justify-center">
             <img
               loading="lazy"
               src={product.imageUrl || '/img/placeholder.png'}
@@ -360,12 +389,12 @@
               className="w-full h-full object-contain"
             />
           </div>
-          <div className="p-4 flex-grow flex flex-col">
+          <div className="flex-grow flex flex-col">
             <h3 className="font-bold text-lg leading-tight" style={{color:'var(--brand-green)'}}>{product.name}</h3>
             <p className="text-xs text-gray-500 mt-1">Código(s): {product.codes || "-"}</p>
-            <p className="text-sm font-semibold mb-3" style={{color:'var(--brand-red)'}}>Sabores: <span className="font-normal text-gray-700">{product.flavors || '-'}</span></p>
+            <p className="text-sm font-semibold" style={{color:'var(--brand-red)'}}>Sabores: <span className="font-normal text-gray-700">{product.flavors || '-'}</span></p>
             {showPrices && (
-              <div className="mt-auto pt-3 border-t space-y-2">
+              <div className="mt-3 pt-3 border-t space-y-2">
                 {(priceMode === 'avista' || priceMode === 'both') && (
                   <>
                     <div className="pl-3 py-1 border-l-4 border-green-500 flex justify-center items-center">
@@ -483,9 +512,14 @@
         contentRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
       };
 
-      const order = (catalog.settings.categoriesOrder && catalog.settings.categoriesOrder.length)
-        ? catalog.settings.categoriesOrder
-        : [...new Set((catalog.products || []).map(p => p.category).filter(Boolean))].sort();
+      let order = ALLOWED_CATEGORIES;
+      const settingsOrder = catalog.settings.categoriesOrder || [];
+      if (
+        settingsOrder.length === ALLOWED_CATEGORIES.length &&
+        ALLOWED_CATEGORIES.every(c => settingsOrder.includes(c))
+      ) {
+        order = settingsOrder.filter(c => ALLOWED_CATEGORIES.includes(c));
+      }
       const grouped = (activeCategory? [activeCategory] : order).map(c => ({
         category: c,
         products: catalog.products
@@ -500,38 +534,51 @@
             <h1 className="text-4xl font-extrabold text-green-700 mb-2">Seja bem-vindo ao nosso catálogo!</h1>
             <p className="text-gray-700">Explore nossas ofertas e aproveite ótimos preços.</p>
           </div>
-          <div className="my-8 text-center">
-            <h2 className="text-3xl font-bold mb-2 text-white" style={{textShadow:'1px 1px 3px rgba(0,0,0,0.5)'}}>Certificações</h2>
-            <p className="max-w-2xl mx-auto mb-8 text-white" style={{textShadow:'1px 1px 3px rgba(0,0,0,0.4)'}}>Seguimos recomendações rigorosas e controle de qualidade.</p>
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-              {[
-                {src:'https://group-ism.com/br/wp-content/uploads/2023/07/ism-9001.png', title:'ISO 9001', desc:'Gestão da qualidade e melhoria contínua.'},
-                {src:'https://group-ism.com/br/wp-content/uploads/2023/07/ism-14001.png', title:'ISO 14001', desc:'Gestão ambiental e proteção do meio ambiente.'},
-                {src:'https://group-ism.com/br/wp-content/uploads/2023/07/ism-45001-ES.png', title:'ISO 45001', desc:'Segurança e saúde ocupacional no trabalho.'},
-              ].map((it,idx)=>(
-                <div key={idx} className="text-white">
-                  <div className="iso-round shadow-lg">
-                    <img loading="lazy" src={it.src} alt={it.title} onError={(e)=>{e.target.style.display='none'; e.target.parentElement.innerHTML = `<span class='text-xs text-gray-500'>Imagem não<br>disponível</span>`}} />
-                  </div>
-                  <h3 className="font-bold text-lg">{it.title}</h3>
-                  <p className="text-sm opacity-90">{it.desc}</p>
+          {!activeCategory && !query && (
+            <>
+              <div className="my-8 text-center">
+                <h2 className="text-3xl font-bold mb-2 text-white" style={{textShadow:'1px 1px 3px rgba(0,0,0,0.5)'}}>Certificações</h2>
+                <p className="max-w-2xl mx-auto mb-8 text-white" style={{textShadow:'1px 1px 3px rgba(0,0,0,0.4)'}}>Seguimos recomendações rigorosas e controle de qualidade.</p>
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+                  {[
+                    {src:'https://group-ism.com/br/wp-content/uploads/2023/07/ism-9001.png', title:'ISO 9001', desc:'Gestão da qualidade e melhoria contínua.'},
+                    {src:'https://group-ism.com/br/wp-content/uploads/2023/07/ism-14001.png', title:'ISO 14001', desc:'Gestão ambiental e proteção do meio ambiente.'},
+                    {src:'https://group-ism.com/br/wp-content/uploads/2023/07/ism-45001-ES.png', title:'ISO 45001', desc:'Segurança e saúde ocupacional no trabalho.'},
+                  ].map((it,idx)=>(
+                    <div key={idx} className="text-white">
+                      <div className="iso-round shadow-lg">
+                        <img loading="lazy" src={it.src} alt={it.title} onError={(e)=>{e.target.style.display='none'; e.target.parentElement.innerHTML = `<span class='text-xs text-gray-500'>Imagem não<br>disponível</span>`}} />
+                      </div>
+                      <h3 className="font-bold text-lg">{it.title}</h3>
+                      <p className="text-sm opacity-90">{it.desc}</p>
+                    </div>
+                  ))}
                 </div>
-              ))}
-            </div>
-          </div>
+              </div>
 
-          <div className="banner mb-6 rounded-2xl overflow-hidden shadow-lg">
-            <img loading="lazy" src="https://i.ibb.co/yFDqWmt0/IMG-0854.jpg" alt="Banner Topo" onError={(e)=>{e.target.src='https://placehold.co/1200x340/0f8a3a/ffffff?text=Banner'}}/>
-          </div>
+              <div className="mb-8 rounded-2xl overflow-hidden shadow-lg">
+                <img loading="lazy" src="/img/banners/brussels.jpg" alt="Cerveja Brussels" className="w-full h-64 object-cover" onError={(e)=>{e.target.style.display='none'; e.target.parentElement.style.display='none';}}/>
+                <div className="p-6 text-gray-800 bg-white/95 border border-gray-100">
+                  <h3 className="text-2xl font-bold mb-2 text-green-700">Brussels Pure Malte: a cerveja que se tornou febre nas redes sociais.</h3>
+                  <p className="mb-4">Com campanhas estreladas por Ronaldinho Gaúcho, a Brussels chega com reconhecimento imediato do público.</p>
+                  <p>Seus rótulos chamam a atenção na geladeira e os formatos (lata 350 ml e garrafa 275 ml) são perfeitos para expor. Com um preço que garante ótima margem, o giro é certo.</p>
+                </div>
+              </div>
+
+              <div className="banner mb-6 rounded-2xl overflow-hidden shadow-lg">
+                <img loading="lazy" src="https://i.ibb.co/yFDqWmt0/IMG-0854.jpg" alt="Banner Topo" onError={(e)=>{e.target.src='https://placehold.co/1200x340/0f8a3a/ffffff?text=Banner'}}/>
+              </div>
+            </>
+          )}
 
           <div ref={contentRef} className="panel p-6 mb-8">
             <div className="flex flex-wrap items-center justify-between gap-4 mb-4">
-              <div className="flex flex-wrap items-center gap-2">
-                <button onClick={() => handleCategoryClick(null)} className={`px-4 py-2 text-sm font-semibold rounded-full transition-colors ${!activeCategory? 'bg-green-600 text-white':'bg-gray-100 text-gray-700 hover:bg-gray-200'}`}>
+              <div className="flex items-center gap-2 overflow-x-auto pb-2">
+                <button onClick={() => handleCategoryClick(null)} className={`flex-shrink-0 px-4 py-2 text-sm font-semibold rounded-full transition-colors ${!activeCategory? 'bg-green-600 text-white':'bg-gray-100 text-gray-700 hover:bg-gray-200'}`}>
                   <span className="inline-flex items-center gap-1">{getCategoryIcon('Todas')} Todas</span>
                 </button>
                 {order.map(cat => (
-                  <button key={cat} onClick={() => handleCategoryClick(cat)} className={`px-4 py-2 text-sm font-semibold rounded-full transition-colors ${activeCategory===cat? 'bg-green-600 text-white':'bg-gray-100 text-gray-700 hover:bg-gray-200'}`}>
+                  <button key={cat} onClick={() => handleCategoryClick(cat)} className={`flex-shrink-0 px-4 py-2 text-sm font-semibold rounded-full transition-colors ${activeCategory===cat? 'bg-green-600 text-white':'bg-gray-100 text-gray-700 hover:bg-gray-200'}`}>
                     <span className="inline-flex items-center gap-1">{getCategoryIcon(cat)} {cat}</span>
                   </button>
                 ))}
@@ -550,27 +597,27 @@
                 )}
               </div>
             </div>
-            <form onSubmit={handleSearchSubmit} className="relative">
+            <form onSubmit={handleSearchSubmit} className="flex flex-wrap items-center gap-2">
               <input
                 ref={searchRef}
                 type="text"
                 placeholder="Buscar por nome, categoria ou código..."
                 value={query}
                 onChange={(e) => setQuery(e.target.value)}
-                className="w-full pl-4 pr-64 py-3 bg-white border border-gray-300 text-gray-900 rounded-full focus:outline-none focus:ring-2 focus:ring-green-500"
+                className="flex-1 w-full px-4 py-3 bg-white border border-gray-300 text-gray-900 rounded-full focus:outline-none focus:ring-2 focus:ring-green-500"
               />
               {query && (
                 <button
                   type="button"
                   onClick={()=>{ setQuery(''); loadCatalog('', activeCategory); }}
-                  className="absolute top-1/2 right-40 -translate-y-1/2 text-sm text-gray-500 hover:text-gray-700"
+                  className="px-4 py-2 bg-gray-200 text-gray-700 rounded-full text-sm hover:bg-gray-300"
                 >
-                  Limpar
+                  Limpar busca
                 </button>
               )}
               <button
                 type="submit"
-                className="absolute top-1/2 right-2 -translate-y-1/2 bg-green-600 text-white font-semibold px-6 py-2 rounded-full hover:bg-green-700 transition-colors"
+                className="px-6 py-2 bg-green-600 text-white font-semibold rounded-full hover:bg-green-700 transition-colors"
               >
                 Buscar
               </button>
@@ -592,30 +639,13 @@
           ) : (
             <>
               {grouped.map(group=>{
-              const hasWaveBg = ['Bebidas não alcoólicas','Bomboneire','Utilidades'].includes(group.category);
+              const hasWaveBg = ['Bebidas não alcoólicas','Bombonière','Utilidades'].includes(group.category);
               const content = (
                 <>
                   {group.category === 'Bebidas alcoólicas' && (
-                    <>
-                      <div className="mb-6 rounded-2xl overflow-hidden shadow-lg">
-                        <img loading="lazy" src="https://i.ibb.co/Vp9Pshb4/IMG-0863.jpg" alt="Novas Cervejas" className="w-full h-auto max-h-340 object-contain"/>
-                      </div>
-                      <div className="rounded-2xl shadow-lg p-6 mb-6 text-gray-800 bg-[#F7F7F7] border-2 border-black">
-                        <h3 className="text-2xl font-bold mb-2 text-green-700">Brussels Pure Malte: a cerveja que se tornou febre nas redes sociais.</h3>
-                        <p className="mb-4">Com campanhas estreladas por Ronaldinho Gaúcho, a Brussels chega com reconhecimento imediato do público.</p>
-                        <div className="grid md:grid-cols-2 gap-4 mb-4">
-                          <div className="bg-white rounded-lg p-4 border-l-4" style={{borderColor:'#1E7E34'}}>
-                            <h4 className="text-lg font-bold mb-1" style={{color:'#1E7E34'}}>Lager</h4>
-                            <p className="text-sm">Puro malte leve e refrescante.</p>
-                          </div>
-                          <div className="bg-white rounded-lg p-4 border-l-4" style={{borderColor:'#004085'}}>
-                            <h4 className="text-lg font-bold mb-1" style={{color:'#004085'}}>Ultra</h4>
-                            <p className="text-sm">Puro malte zero açúcar e zero carboidrato, com o mesmo teor alcoólico e um sabor incrivelmente limpo.</p>
-                          </div>
-                        </div>
-                        <p>Seus rótulos chamam a atenção na geladeira e os formatos (lata 350 ml e garrafa 275 ml) são perfeitos para expor. Com um preço que garante ótima margem, o giro é certo: a curiosidade do seu cliente traz o primeiro pedido, o sabor garante a recompra. Tenha em seu ponto de venda a novidade que todos já estão procurando!</p>
-                      </div>
-                    </>
+                    <div className="mb-6 rounded-2xl overflow-hidden shadow-lg">
+                      <img loading="lazy" src="/img/banners/bebidas-alcoolicas.jpg" alt="Bebidas alcoólicas" className="w-full h-48 object-cover" onError={(e)=>{e.target.style.display='none'; e.target.parentElement.style.display='none';}}/>
+                    </div>
                   )}
                   {group.category === 'Bebidas não alcoólicas' && (
                     <div className="mb-8 panel p-6 overflow-hidden text-gray-800">
@@ -988,7 +1018,7 @@
       }
     };
 
-    ReactDOM.render(<AppProvider><Header/><main><App/></main></AppProvider>, document.getElementById('root'));
+    ReactDOM.render(<AppProvider><Header/><OfflineNotice/><main><App/></main></AppProvider>, document.getElementById('root'));
 
     if ('serviceWorker' in navigator){
       window.addEventListener('load', async ()=>{

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,51 +1,115 @@
-const VERSION = 'v5';
-const CORE = [
-  '/',
-  '/index.html',
-  '/img/placeholder.png'
-];
+const STATIC_CACHE = 'iv-static-v1';
+const DATA_CACHE = 'iv-data-v1';
+let offlineEnabled = false;
 
-let OFFLINE_ENABLED = false;
+// Recupera estado salvo do modo offline
+caches.open(DATA_CACHE).then(cache => {
+  cache.match('offline-enabled').then(res => { offlineEnabled = !!res; });
+});
 
-self.addEventListener('message', (e)=>{
-  if (e.data && e.data.type === 'offline') {
-    OFFLINE_ENABLED = !!e.data.enabled;
+self.addEventListener('message', event => {
+  const msg = event.data || {};
+  if (msg.type === 'ENABLE_OFFLINE') {
+    offlineEnabled = true;
+    event.waitUntil((async () => {
+      const staticCache = await caches.open(STATIC_CACHE);
+      await staticCache.addAll(['/', '/index.html', '/img/placeholder.png']);
+      const dataCache = await caches.open(DATA_CACHE);
+      await dataCache.add('/api/catalog');
+      await dataCache.put('offline-enabled', new Response('true'));
+    })());
+  }
+  if (msg.type === 'DISABLE_OFFLINE') {
+    offlineEnabled = false;
+    event.waitUntil((async () => {
+      await caches.delete(DATA_CACHE);
+    })());
   }
 });
 
-self.addEventListener('install', (e)=>{
+self.addEventListener('install', event => {
   self.skipWaiting();
-  e.waitUntil(caches.open('core-'+VERSION).then(c=>c.addAll(CORE)));
 });
 
-self.addEventListener('activate', (e)=>{
-  e.waitUntil((async ()=>{
+self.addEventListener('activate', event => {
+  event.waitUntil((async () => {
     const keys = await caches.keys();
-    await Promise.all(keys.map(k=>{
-      if (!k.endsWith(VERSION)) return caches.delete(k);
+    await Promise.all(keys.map(k => {
+      if (![STATIC_CACHE, DATA_CACHE].includes(k)) return caches.delete(k);
     }));
     await self.clients.claim();
   })());
 });
 
-self.addEventListener('fetch', (e)=>{
-  const req = e.request;
-  const url = new URL(req.url);
+self.addEventListener('fetch', event => {
+  const req = event.request;
   if (req.method !== 'GET') return;
-  // Network-first for API
-  if (url.pathname.startsWith('/api/')){
-    e.respondWith(fetch(req).catch(()=>caches.match(req)));
+  const url = new URL(req.url);
+
+  // Catálogo: stale-while-revalidate
+  if (url.pathname === '/api/catalog') {
+    event.respondWith((async () => {
+      const cache = await caches.open(DATA_CACHE);
+      const cached = await cache.match(req);
+      const fetchPromise = fetch(req).then(res => {
+        if (offlineEnabled && res.ok) cache.put(req, res.clone());
+        return res;
+      }).catch(() => null);
+      if (cached) {
+        fetchPromise;
+        return cached;
+      }
+      return fetchPromise;
+    })());
     return;
   }
-  e.respondWith((async ()=>{
-    const cache = await caches.open('sw-'+VERSION);
-    const cached = await cache.match(req);
+
+  // Demais APIs: network-first
+  if (url.pathname.startsWith('/api/')) {
+    event.respondWith((async () => {
+      const cache = await caches.open(DATA_CACHE);
+      try {
+        const res = await fetch(req);
+        if (offlineEnabled && res.ok) cache.put(req, res.clone());
+        return res;
+      } catch (err) {
+        const cached = await cache.match(req);
+        if (cached) return cached;
+        throw err;
+      }
+    })());
+    return;
+  }
+
+  // Imagens: cache-first
+  if (req.destination === 'image') {
+    event.respondWith((async () => {
+      const cache = await caches.open(STATIC_CACHE);
+      const cached = await cache.match(req);
+      if (cached) return cached;
+      try {
+        const res = await fetch(req);
+        if (res.ok) cache.put(req, res.clone());
+        return res;
+      } catch (err) {
+        return cached;
+      }
+    })());
+    return;
+  }
+
+  // Demais requisições GET
+  event.respondWith((async () => {
+    const cache = await caches.open(STATIC_CACHE);
     try {
       const res = await fetch(req);
-      if (OFFLINE_ENABLED && res.ok) cache.put(req, res.clone());
+      if (offlineEnabled && res.ok) cache.put(req, res.clone());
       return res;
-    } catch(err) {
-      return cached;
+    } catch (err) {
+      const cached = await cache.match(req);
+      if (cached) return cached;
+      throw err;
     }
   })());
 });
+


### PR DESCRIPTION
## Summary
- refine header layout and product cards for 10" tablets
- add offline mode messaging and notice with service worker caching
- restrict visible catalog categories and restore home banners

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b63dfd09348333996a573ff7f7c09b